### PR TITLE
Change default behavior for MaxLen

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,15 +22,16 @@ import (
 	"runtime"
 	"syscall"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/jessevdk/go-flags"
+	log "github.com/sirupsen/logrus"
 )
 
 var commandOpts struct {
-	Debug    bool `short:"d" long:"debug" description:"Show verbose debug information"`
-	Interval int  `short:"i" long:"interval" default:"5" description:"Specify interval(1-59 min) for reloading pseudo ROA table"`
-	Port     int  `short:"p" long:"port" default:"323" description:"Specify listen port for RTR"`
-	Quiet    bool `short:"q" long:"quiet" description:"Quiet mode"`
+	Debug     bool `short:"d" long:"debug" description:"Show verbose debug information"`
+	Interval  int  `short:"i" long:"interval" default:"5" description:"Specify interval(1-59 min) for reloading pseudo ROA table"`
+	UseMaxLen bool `short:"m" long:"maxlen" description:"Use 32 or 128 as MaxLen value, 32 for IPv4, 128 for IPv6. By default(=false), use the same length to the prefix length"`
+	Port      int  `short:"p" long:"port" default:"323" description:"Specify listen port for RTR"`
+	Quiet     bool `short:"q" long:"quiet" description:"Quiet mode"`
 }
 
 func checkError(err error) {
@@ -119,7 +120,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr := NewResourceManager()
+	mgr := NewResourceManager(commandOpts.UseMaxLen)
 	mainLoop(mgr, args, commandOpts.Port, interval, commandOpts.Debug, commandOpts.Quiet, sigCh)
 	log.Infof("Daemon stopped")
 }

--- a/resource_manager.go
+++ b/resource_manager.go
@@ -72,12 +72,14 @@ type Response struct {
 type ResourceManager struct {
 	ch           chan Request
 	serialNotify *bcast.Group
+	useMaxLen    bool
 	init         sync.Once
 }
 
-func NewResourceManager() *ResourceManager {
+func NewResourceManager(useMaxLen bool) *ResourceManager {
 	return &ResourceManager{
 		ch:           make(chan Request),
+		useMaxLen:    useMaxLen,
 		serialNotify: bcast.NewGroup(),
 	}
 }
@@ -157,7 +159,7 @@ func handleRequests(mgr *ResourceManager, rsrc *resource) {
 		req := <-mgr.ch
 		switch req.RequestType {
 		case REQ_LOAD:
-			rsrc, err = newResource(req.Key.([]string))
+			rsrc, err = newResource(req.Key.([]string), mgr.useMaxLen)
 			log.Infof("Resource has been loaded. (SN: %v)", rsrc.currentSN)
 			req.Response <- &Response{Error: err}
 		case REQ_CURRENT_SERIAL:

--- a/rtr_test.go
+++ b/rtr_test.go
@@ -23,7 +23,7 @@ func prepare(content []string) (*ResourceManager, *os.File) {
 	rpslFile, _ := ioutil.TempFile(os.TempDir(), "rtr_test.db")
 	addRPSL(rpslFile, content)
 
-	mgr := NewResourceManager()
+	mgr := NewResourceManager(false)
 	go mainLoop(mgr, []string{rpslFile.Name()}, 42420, 2, false, true, nil)
 	return mgr, rpslFile
 }


### PR DESCRIPTION
  * By default, the same value to prefix length are used.
  * If you want to use 32 for IPv4 and 128 for IPv6 as MaxLen, Specify
-m option.